### PR TITLE
🐛 FIX: Point CFFormat workflow to new Ortus box action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - uses: michaelborn/commandbox-action@v1
+      - uses: Ortus-Solutions/commandbox-action@v1
         with:
           cmd: cfformat run path=models,handlers,interceptors,wires,tests/specs --overwrite
 


### PR DESCRIPTION
I noticed the CFFormat builds were broken... probably because I moved my `michaelborn/commandbox-action` to `Ortus-Solutions/commandbox-action` shortly after creating this workflow. My bad!